### PR TITLE
Status must be a integer

### DIFF
--- a/src/Purchases/Decoder.php
+++ b/src/Purchases/Decoder.php
@@ -22,7 +22,7 @@ abstract class Decoder
         return new Details(
             (string) $obj->code,
             isset($obj->reference) ? (string) $obj->reference : null,
-            (string) $obj->status,
+            (int) $obj->status,
             new DateTime((string) $obj->date),
             new DateTime((string) $obj->lastEventDate),
             $this->createCustomer($obj->sender)

--- a/src/Purchases/Details.php
+++ b/src/Purchases/Details.php
@@ -57,7 +57,7 @@ class Details
     ) {
         $this->code = $code;
         $this->reference = $reference;
-        $this->status = (int) $status;
+        $this->status = $status;
         $this->date = $date;
         $this->lastEventDate = $lastEventDate;
         $this->customer = $customer;


### PR DESCRIPTION
O retorno dos detalhes está trazendo o status como string. Para conseguir comparar utilizando os métodos da classe Transaction, ele precisa ser integer.
