### PR TITLE
Novo método estático para criação de Credentials

### DIFF
--- a/src/Credentials.php
+++ b/src/Credentials.php
@@ -3,6 +3,7 @@ namespace PHPSC\PagSeguro;
 
 use PHPSC\PagSeguro\Environment;
 use PHPSC\PagSeguro\Environments\Production;
+use PHPSC\PagSeguro\Environments\Sandbox;
 
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
@@ -65,4 +66,19 @@ class Credentials
             http_build_query($params)
         );
     }
+    
+    /**
+     * @return Credentials $credentials
+     */
+    static public function createFromEnv()
+    {
+        return new Credentials(
+            getenv('PAGSEGURO_EMAIL'),
+            getenv('PAGSEGURO_ENV') == 'SANDBOX' ? 
+                        getenv('PAGSEGURO_TOKEN_SANDBOX') : 
+                        getenv('PAGSEGURO_TOKEN_PRODUCTION'),
+            getenv('PAGSEGURO_ENV') == 'SANDBOX' ? new Sandbox() : new Production(),
+        );
+    }
+    
 }

--- a/src/Credentials.php
+++ b/src/Credentials.php
@@ -77,7 +77,7 @@ class Credentials
             getenv('PAGSEGURO_ENV') == 'SANDBOX' ? 
                         getenv('PAGSEGURO_TOKEN_SANDBOX') : 
                         getenv('PAGSEGURO_TOKEN_PRODUCTION'),
-            getenv('PAGSEGURO_ENV') == 'SANDBOX' ? new Sandbox() : new Production(),
+            getenv('PAGSEGURO_ENV') == 'SANDBOX' ? new Sandbox() : new Production()
         );
     }
     


### PR DESCRIPTION
Adiciona um método que cria um `Credentials` usando variáveis de environment. Isso evita ter que criar uma classe que gerencia a `Credentials` ou que toda hora seja necessário dar um `new Credentials(...)`. Pode-se, futuramente, para não criar um novo objeto a cada chamada, criar um objeto estático singleton.