### PR TITLE
Minor fixes to correct standardization

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Client;
 
 use GuzzleHttp\Event\ErrorEvent as Event;

--- a/src/Client/PagSeguroException.php
+++ b/src/Client/PagSeguroException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Client;
 
 use GuzzleHttp\Message\Response;

--- a/src/Credentials.php
+++ b/src/Credentials.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro;
 
 use PHPSC\PagSeguro\Environment;

--- a/src/Customer/Address.php
+++ b/src/Customer/Address.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Customer;
 
 class Address

--- a/src/Customer/Customer.php
+++ b/src/Customer/Customer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Customer;
 
 class Customer

--- a/src/Customer/Phone.php
+++ b/src/Customer/Phone.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Customer;
 
 class Phone

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro;
 
 use PHPSC\PagSeguro\Environments\Production;

--- a/src/Environments/Production.php
+++ b/src/Environments/Production.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Environments;
 
 use PHPSC\PagSeguro\Environment;

--- a/src/Environments/Sandbox.php
+++ b/src/Environments/Sandbox.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Environments;
 
 use PHPSC\PagSeguro\Environment;

--- a/src/Items/Item.php
+++ b/src/Items/Item.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Items;
 
 /**

--- a/src/Items/ItemCollection.php
+++ b/src/Items/ItemCollection.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Items;
 
 use Doctrine\Common\Collections\Collection;

--- a/src/Items/Items.php
+++ b/src/Items/Items.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Items;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/src/Purchases/ChargeBuilder.php
+++ b/src/Purchases/ChargeBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases;
 
 use PHPSC\PagSeguro\Items\Item;

--- a/src/Purchases/Decoder.php
+++ b/src/Purchases/Decoder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases;
 
 use DateTime;

--- a/src/Purchases/NotificationService.php
+++ b/src/Purchases/NotificationService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases;
 
 use PHPSC\PagSeguro\Purchases\Transactions\Transaction;

--- a/src/Purchases/SearchService.php
+++ b/src/Purchases/SearchService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases;
 
 use PHPSC\PagSeguro\Purchases\Transaction;

--- a/src/Purchases/SubscriptionService.php
+++ b/src/Purchases/SubscriptionService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases;
 
 use PHPSC\PagSeguro\Purchases\Subscriptions\Charge;

--- a/src/Purchases/Subscriptions/CancellationResponse.php
+++ b/src/Purchases/Subscriptions/CancellationResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Subscriptions;
 
 use DateTime;

--- a/src/Purchases/Subscriptions/Charge.php
+++ b/src/Purchases/Subscriptions/Charge.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Subscriptions;
 
 use PHPSC\PagSeguro\Items\ItemCollection;

--- a/src/Purchases/Subscriptions/ChargeBuilder.php
+++ b/src/Purchases/Subscriptions/ChargeBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Subscriptions;
 
 use PHPSC\PagSeguro\Items\Item;

--- a/src/Purchases/Subscriptions/ChargeResponse.php
+++ b/src/Purchases/Subscriptions/ChargeResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Subscriptions;
 
 use DateTime;

--- a/src/Purchases/Subscriptions/ChargeSerializer.php
+++ b/src/Purchases/Subscriptions/ChargeSerializer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Subscriptions;
 
 use PHPSC\PagSeguro\Requests\Serializer;

--- a/src/Purchases/Subscriptions/Decoder.php
+++ b/src/Purchases/Subscriptions/Decoder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Subscriptions;
 
 use PHPSC\PagSeguro\Purchases\Decoder as BaseDecoder;

--- a/src/Purchases/Subscriptions/Locator.php
+++ b/src/Purchases/Subscriptions/Locator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Subscriptions;
 
 use PHPSC\PagSeguro\Client\Client;

--- a/src/Purchases/Subscriptions/Subscription.php
+++ b/src/Purchases/Subscriptions/Subscription.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Subscriptions;
 
 use PHPSC\PagSeguro\Purchases\Details;
@@ -64,7 +65,7 @@ class Subscription
     }
 
     /**
-     * @return TransactionDetails
+     * @return Details
      */
     public function getDetails()
     {

--- a/src/Purchases/Subscriptions/SubscriptionService.php
+++ b/src/Purchases/Subscriptions/SubscriptionService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Subscriptions;
 
 use DateTime;

--- a/src/Purchases/Transactions/Decoder.php
+++ b/src/Purchases/Transactions/Decoder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Transactions;
 
 use DateTime;

--- a/src/Purchases/Transactions/Locator.php
+++ b/src/Purchases/Transactions/Locator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Transactions;
 
 use PHPSC\PagSeguro\Credentials;

--- a/src/Purchases/Transactions/Payment.php
+++ b/src/Purchases/Transactions/Payment.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Transactions;
 
 use DateTime;

--- a/src/Purchases/Transactions/PaymentMethod.php
+++ b/src/Purchases/Transactions/PaymentMethod.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Transactions;
 
 class PaymentMethod

--- a/src/Purchases/Transactions/Transaction.php
+++ b/src/Purchases/Transactions/Transaction.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Transactions;
 
 use DateTime;
@@ -93,7 +94,7 @@ class Transaction
     }
 
     /**
-     * @return TransactionDetails
+     * @return Details
      */
     public function getDetails()
     {

--- a/src/Requests/Checkout/Checkout.php
+++ b/src/Requests/Checkout/Checkout.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\Checkout;
 
 use PHPSC\PagSeguro\Customer\Customer;

--- a/src/Requests/Checkout/CheckoutBuilder.php
+++ b/src/Requests/Checkout/CheckoutBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\Checkout;
 
 use PHPSC\PagSeguro\Customer\Customer;

--- a/src/Requests/Checkout/CheckoutSerializer.php
+++ b/src/Requests/Checkout/CheckoutSerializer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\Checkout;
 
 use PHPSC\PagSeguro\Requests\Checkout\Checkout;

--- a/src/Requests/Checkout/CheckoutService.php
+++ b/src/Requests/Checkout/CheckoutService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\Checkout;
 
 use PHPSC\PagSeguro\Requests\CheckoutService as CheckoutServiceInterface;

--- a/src/Requests/Checkout/Order.php
+++ b/src/Requests/Checkout/Order.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\Checkout;
 
 use PHPSC\PagSeguro\Items\ItemCollection;

--- a/src/Requests/CheckoutBuilder.php
+++ b/src/Requests/CheckoutBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests;
 
 use PHPSC\PagSeguro\Customer\Customer;

--- a/src/Requests/CheckoutService.php
+++ b/src/Requests/CheckoutService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests;
 
 use PHPSC\PagSeguro\Requests\Checkout\Checkout;

--- a/src/Requests/PreApprovalService.php
+++ b/src/Requests/PreApprovalService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests;
 
 use PHPSC\PagSeguro\Requests\PreApprovals\Request;

--- a/src/Requests/PreApprovals/ChargeType.php
+++ b/src/Requests/PreApprovals/ChargeType.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\PreApprovals;
 
 /**

--- a/src/Requests/PreApprovals/Period.php
+++ b/src/Requests/PreApprovals/Period.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\PreApprovals;
 
 /**

--- a/src/Requests/PreApprovals/PreApproval.php
+++ b/src/Requests/PreApprovals/PreApproval.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\PreApprovals;
 
 use DateTime;

--- a/src/Requests/PreApprovals/PreApprovalService.php
+++ b/src/Requests/PreApprovals/PreApprovalService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\PreApprovals;
 
 use PHPSC\PagSeguro\Client\Client;

--- a/src/Requests/PreApprovals/Request.php
+++ b/src/Requests/PreApprovals/Request.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\PreApprovals;
 
 use PHPSC\PagSeguro\Customer\Customer;

--- a/src/Requests/PreApprovals/RequestBuilder.php
+++ b/src/Requests/PreApprovals/RequestBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\PreApprovals;
 
 use DateTime;

--- a/src/Requests/PreApprovals/RequestSerializer.php
+++ b/src/Requests/PreApprovals/RequestSerializer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\PreApprovals;
 
 use DateTime;

--- a/src/Requests/Redirection.php
+++ b/src/Requests/Redirection.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests;
 
 use DateTime;

--- a/src/Requests/RequestBuilder.php
+++ b/src/Requests/RequestBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests;
 
 use DateTime;

--- a/src/Requests/Serializer.php
+++ b/src/Requests/Serializer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests;
 
 use PHPSC\PagSeguro\Customer\Address;

--- a/src/Requests/Service.php
+++ b/src/Requests/Service.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests;
 
 use DateTime;

--- a/src/Service.php
+++ b/src/Service.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro;
 
 use PHPSC\PagSeguro\Client\Client;

--- a/src/Shipping/Shipping.php
+++ b/src/Shipping/Shipping.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Shipping;
 
 use InvalidArgumentException;

--- a/src/Shipping/Type.php
+++ b/src/Shipping/Type.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Shipping;
 
 /**

--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Client;
 
 use GuzzleHttp\Event\ErrorEvent as Event;

--- a/tests/Client/PagSeguroExceptionTest.php
+++ b/tests/Client/PagSeguroExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Client;
 
 use GuzzleHttp\Stream\Stream;

--- a/tests/CredentialsTest.php
+++ b/tests/CredentialsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro;
 
 use PHPSC\PagSeguro\Environments\Production;

--- a/tests/Customer/AddressTest.php
+++ b/tests/Customer/AddressTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Customer;
 
 class AddressTest extends \PHPUnit_Framework_TestCase

--- a/tests/Customer/CustomerTest.php
+++ b/tests/Customer/CustomerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Customer;
 
 class CustomerTest extends \PHPUnit_Framework_TestCase

--- a/tests/Customer/PhoneTest.php
+++ b/tests/Customer/PhoneTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Customer;
 
 class PhoneTest extends \PHPUnit_Framework_TestCase

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro;
 
 use PHPSC\PagSeguro\Environments\Production;

--- a/tests/Environments/ProductionTest.php
+++ b/tests/Environments/ProductionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Environments;
 
 /**

--- a/tests/Environments/SandboxTest.php
+++ b/tests/Environments/SandboxTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Environments;
 
 /**

--- a/tests/Items/ItemTest.php
+++ b/tests/Items/ItemTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Items;
 
 class ItemTest extends \PHPUnit_Framework_TestCase

--- a/tests/Purchases/Transactions/LocatorTest.php
+++ b/tests/Purchases/Transactions/LocatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Transactions;
 
 use PHPSC\PagSeguro\Credentials;

--- a/tests/Purchases/Transactions/PaymentMethodTest.php
+++ b/tests/Purchases/Transactions/PaymentMethodTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Purchases\Transactions;
 
 class PaymentMethodTest extends \PHPUnit_Framework_TestCase

--- a/tests/Requests/Checkout/CheckoutBuilderTest.php
+++ b/tests/Requests/Checkout/CheckoutBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\Checkout;
 
 use PHPSC\PagSeguro\Customer\Customer;

--- a/tests/Requests/Checkout/CheckoutServiceTest.php
+++ b/tests/Requests/Checkout/CheckoutServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\Checkout;
 
 use DateTime;

--- a/tests/Requests/Checkout/CheckoutTest.php
+++ b/tests/Requests/Checkout/CheckoutTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\Checkout;
 
 use PHPSC\PagSeguro\Customer\Customer;

--- a/tests/Requests/Checkout/OrderTest.php
+++ b/tests/Requests/Checkout/OrderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests\Checkout;
 
 use PHPSC\PagSeguro\Items\ItemCollection;

--- a/tests/Requests/RedirectionTest.php
+++ b/tests/Requests/RedirectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Requests;
 
 use DateTime;

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro;
 
 use PHPSC\PagSeguro\Client\Client;

--- a/tests/Shipping/ShippingTest.php
+++ b/tests/Shipping/ShippingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHPSC\PagSeguro\Shipping;
 
 use PHPSC\PagSeguro\Customer\Address;


### PR DESCRIPTION
* Fix space between opening php tag and namespace declaration
* Fix typehint in Transaction::getDetails() and Subscription::getDetails() to use correct Details