### PR TITLE
Implementado a funcionalidade de setar notificationURL no Checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.settings
 /.buildpath
 /.project
+/.idea

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A instalação desta biblioteca pode ser feita utilizando o [Composer](https://p
 Nesta versão é possível gerenciar:
 
 * Solicitações (pagamentos e assinaturas);
-* Notificações
+* Notificações v.2
 * Busca por código (pagamentos e assinaturas);
 * Cancelamento e cobrança de assinaturas.
 

--- a/src/Requests/Checkout/Checkout.php
+++ b/src/Requests/Checkout/Checkout.php
@@ -34,6 +34,11 @@ class Checkout
     private $maxAge;
 
     /**
+     * @var string
+     */
+    private $notificationURL;
+
+    /**
      * @param Order $order
      * @param Customer $customer
      * @param string $redirectTo
@@ -115,5 +120,21 @@ class Checkout
     public function setMaxAge($maxAge)
     {
         $this->maxAge = $maxAge;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNotificationURL()
+    {
+        return $this->notificationURL;
+    }
+
+    /**
+     * @param string $notificationURL
+     */
+    public function setNotificationURL($notificationURL)
+    {
+        $this->notificationURL = $notificationURL;
     }
 }

--- a/src/Requests/Checkout/CheckoutBuilder.php
+++ b/src/Requests/Checkout/CheckoutBuilder.php
@@ -77,6 +77,16 @@ class CheckoutBuilder implements CheckoutBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function setNotificationURL($notificationURL)
+    {
+        $this->checkout->setNotificationURL($notificationURL);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setMaxAge($maxAge)
     {
         $this->checkout->setMaxAge($maxAge);

--- a/src/Requests/Checkout/CheckoutSerializer.php
+++ b/src/Requests/Checkout/CheckoutSerializer.php
@@ -37,6 +37,10 @@ class CheckoutSerializer extends Serializer
             $xml->addChild('redirectURL', $redirectTo);
         }
 
+        if ($notificationURL = $checkout->getNotificationURL()) {
+            $xml->addChild('notificationURL', $notificationURL);
+        }
+
         if ($maxUses = $checkout->getMaxUses()) {
             $xml->addChild('maxUses', $maxUses);
         }

--- a/tests/Requests/Checkout/CheckoutTest.php
+++ b/tests/Requests/Checkout/CheckoutTest.php
@@ -133,4 +133,17 @@ class CheckoutTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($customer, $this->checkout->getCustomer());
     }
+
+    /**
+     * @test
+     */
+    public function setNotificationURLShouldConfigureTheNotificationUri()
+    {
+        $uri = 'http://chibungo.com';
+
+        $this->checkout->setNotificationURL($uri);
+
+        $this->assertAttributeEquals($uri, 'notificationURL', $this->checkout);
+    }
+
 }


### PR DESCRIPTION
Me perdoe a ignorância, mas consegui resolver 99.9% dos meus problemas com o seu projeto. 

Estou mexendo nisso já tem 3 dias e não consegui um bom jeito de fazer o PagSeguro me notificar imediatamente depois da compra. 

O redirectTo seria perfeito se fosse imediato. Se o usuário fechar a janela antes do redirect não consigo salvar no meu banco o ID do usuário e transação.
(Lógico eu teria que manualmente resolver isso no painel de controle do PagSeguro)

Resolvi testar setar uma notificação personalizada pra cada compra: 
Ex.: http://minha-loja/user/{ID-DO-USUARIO}/notifica

Isso resolveu beleza (em sandbox), se houver qualquer mudança na transação eles postarão na url com o código do usuário.

Qualquer feedback eu ficaria imensamente grato. T+