### PR TITLE
Restante na cobertura dos testes unitários - Requests e Purchases

### DIFF
--- a/tests/Items/ItemsTest.php
+++ b/tests/Items/ItemsTest.php
@@ -1,0 +1,21 @@
+<?php
+namespace PHPSC\PagSeguro\Items;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @author Renato Moura <moura137@gmail.com>
+ */
+class ItemsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function constructorShouldInstanceOf()
+    {
+        $items = new Items;
+
+        $this->assertInstanceOf(ArrayCollection::class, $items);
+        $this->assertInstanceOf(ItemCollection::class, $items);
+    }
+}

--- a/tests/Purchases/Subscriptions/ChargeBuilderTest.php
+++ b/tests/Purchases/Subscriptions/ChargeBuilderTest.php
@@ -1,0 +1,48 @@
+<?php
+namespace PHPSC\PagSeguro\Purchases\Subscriptions;
+
+use PHPSC\PagSeguro\Purchases\ChargeBuilder as ChargeBuilderInterface;
+use PHPSC\PagSeguro\Items\Item;
+use PHPSC\PagSeguro\Items\Items;
+
+/**
+ * @author Renato Moura <moura137@gmail.com>
+ */
+class ChargeBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->mockCharge = $this->getMock(Charge::class, [], [], '', false);
+        $this->mockCharge->expects($this->once())->method('setSubscriptionCode')->with('123456');
+    }
+
+    public function testConstructShouldDoCallSetSubscription()
+    {
+        $builder = new ChargeBuilder('123456', $this->mockCharge);
+
+        $this->assertInstanceOf(ChargeBuilderInterface::class, $builder);
+        $this->assertEquals($this->mockCharge, $builder->getCharge());
+
+    }
+
+    public function testAddItemShouldDoCallAddInChargeAndReturnSelfObject()
+    {
+        $item = new Item(99, 'Produto 03', 1.77, 8, 12.9, 360);
+        $items = $this->getMock(Items::class, [], [], '', false);
+        $items->expects($this->once())->method('add')->with($item);
+        $this->mockCharge->expects($this->once())->method('getItems')->willReturn($items);
+
+        $builder = new ChargeBuilder('123456', $this->mockCharge);
+
+        $this->assertEquals($builder, $builder->addItem($item));
+    }
+
+    public function testsetReferenceShouldDoCallInChargeAndReturnSelfObject()
+    {
+        $this->mockCharge->expects($this->once())->method('setReference')->with('ABCDE');
+
+        $builder = new ChargeBuilder('123456', $this->mockCharge);
+
+        $this->assertEquals($builder, $builder->setReference('ABCDE'));
+    }
+}

--- a/tests/Purchases/Subscriptions/DecoderTest.php
+++ b/tests/Purchases/Subscriptions/DecoderTest.php
@@ -1,0 +1,30 @@
+<?php
+namespace PHPSC\PagSeguro\Purchases\Subscriptions;
+
+use DateTime;
+use PHPSC\PagSeguro\Purchases\Details;
+use PHPSC\PagSeguro\Customer\Address;
+use PHPSC\PagSeguro\Customer\Customer;
+use PHPSC\PagSeguro\Customer\Phone;
+
+/**
+ * @author Renato Moura <moura137@gmail.com>
+ */
+class DecoderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDecodeShouldDoReturningObjectSubscription()
+    {
+        $detailsDate = new DateTime('2011-11-23T13:40:00.000-02:00');
+        $detailsLastEventDate = new DateTime('2011-11-25T20:04:00.000-02:00');
+        $detailsAddress = new Address('SP', 'SAO PAULO', '01421000', 'J Paulista', 'ALAMEDAITU', '78', 'ap.2601');
+        $customer = new Customer('comprador@uol.com', 'Nome Comprador', new Phone('11', '30389678'), $detailsAddress);
+        $details = new Details('C08984', 'REF1234', 'CANCELLED', $detailsDate, $detailsLastEventDate, $customer);
+
+        $subscription = new Subscription('Seguro Notebook', $details, '538C53', 'auto');
+
+        $obj = simplexml_load_file(__DIR__.'/xml/preApproval.xml');
+
+        $decoder = new Decoder;
+        $this->assertEquals($subscription, $decoder->decode($obj));
+    }
+}

--- a/tests/Purchases/Subscriptions/LocatorTest.php
+++ b/tests/Purchases/Subscriptions/LocatorTest.php
@@ -1,0 +1,73 @@
+<?php
+namespace PHPSC\PagSeguro\Purchases\Subscriptions;
+
+use PHPSC\PagSeguro\Client\Client;
+use PHPSC\PagSeguro\Credentials;
+use PHPSC\PagSeguro\Purchases\NotificationService;
+use PHPSC\PagSeguro\Purchases\SearchService;
+use PHPSC\PagSeguro\Service;
+use PHPSC\PagSeguro\Purchases\Transactions\Transaction;
+use SimpleXMLElement;
+
+/**
+ * @author Renato Moura <moura137@gmail.com>
+ */
+class LocatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructShouldSettersDecoder()
+    {
+        $credentials = $this->getMock(Credentials::class, [], [], '', false);
+        $client = $this->getMock(CLient::class, [], [], '', false);
+        $decoder = $this->getMock(Decoder::class, [], [], '', false);
+        $locator = new Locator($credentials, $client, $decoder);
+
+        $this->assertInstanceOf(NotificationService::class, $locator);
+        $this->assertInstanceOf(SearchService::class, $locator);
+        $this->assertInstanceOf(Service::class, $locator);
+        $this->assertAttributeSame($decoder, 'decoder', $locator);
+    }
+
+    public function testGetByCodeShouldDoAGetRequestAddingCredentialsData()
+    {
+        $credentials = $this->getMock(Credentials::class, [], [], '', false);
+        $client = $this->getMock(CLient::class, [], [], '', false);
+        $decoder = $this->getMock(Decoder::class, [], [], '', false);
+        $locator = new Locator($credentials, $client, $decoder);
+
+        $wsUrl = 'https://ws.test.com/v2/transactions?token=zzzzz';
+        $credentials->expects($this->once())
+            ->method('getWsUrl')
+            ->with('/v2/pre-approvals/123456', [])
+            ->willReturn($wsUrl);
+
+        $xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><transaction/>');
+        $client->expects($this->once())->method('get')->with($wsUrl)->willReturn($xml);
+
+        $transaction = $this->getMock(Transaction::class, [], [], '', false);
+        $decoder->expects($this->once())->method('decode')->with($xml)->willReturn($transaction);
+
+        $this->assertEquals($transaction, $locator->getByCode('123456'));
+    }
+
+    public function testGetByNotificationShouldDoAGetRequestAddingCredentialsData()
+    {
+        $credentials = $this->getMock(Credentials::class, [], [], '', false);
+        $client = $this->getMock(CLient::class, [], [], '', false);
+        $decoder = $this->getMock(Decoder::class, [], [], '', false);
+        $locator = new Locator($credentials, $client, $decoder);
+
+        $wsUrl = 'https://ws.test.com/v2/transactions?token=xxxxx';
+        $credentials->expects($this->once())
+            ->method('getWsUrl')
+            ->with('/v2/pre-approvals/notifications/abcd', [])
+            ->willReturn($wsUrl);
+
+        $xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><transaction/>');
+        $client->expects($this->once())->method('get')->with($wsUrl)->willReturn($xml);
+
+        $transaction = $this->getMock(Transaction::class, [], [], '', false);
+        $decoder->expects($this->once())->method('decode')->with($xml)->willReturn($transaction);
+
+        $this->assertEquals($transaction, $locator->getByNotification('abcd'));
+    }
+}

--- a/tests/Purchases/Subscriptions/SubscriptionTest.php
+++ b/tests/Purchases/Subscriptions/SubscriptionTest.php
@@ -1,0 +1,123 @@
+<?php
+namespace PHPSC\PagSeguro\Purchases\Subscriptions;
+
+use DateTime;
+use PHPSC\PagSeguro\Purchases\Details;
+use PHPSC\PagSeguro\Customer\Address;
+use PHPSC\PagSeguro\Customer\Customer;
+use PHPSC\PagSeguro\Customer\Phone;
+
+/**
+ * @author Renato Moura <moura137@gmail.com>
+ */
+class SubscriptionTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->dDate = new DateTime('2011-11-23T13:40:00.000-02:00');
+        $this->eventDate = new DateTime('2011-11-25T20:04:00.000-02:00');
+        $this->detailsAddress = new Address('SP', 'SAO PAULO', '01421000', 'J Paulista', 'ALAMEDAITU', '78', 'ap.2601');
+        $this->customer = new Customer('a@uol.com', 'Comprador', new Phone('11', '30389678'), $this->detailsAddress);
+    }
+
+    public function testConstructShouldReturnOfGetters()
+    {
+        $details = new Details('C89', 'R12', '', $this->dDate, $this->eventDate, $this->customer);
+        $subscription = new Subscription('FooBar', $details, 'TRACKER-AAAA', '');
+
+        $this->assertEquals('FooBar', $subscription->getName());
+        $this->assertEquals($details, $subscription->getDetails());
+        $this->assertEquals('TRACKER-AAAA', $subscription->getTracker());
+
+        $this->assertFalse($subscription->isAutomatic());
+        $this->assertFalse($subscription->isManual());
+        $this->assertFalse($subscription->isInitiated());
+        $this->assertFalse($subscription->isPending());
+        $this->assertFalse($subscription->isActive());
+        $this->assertFalse($subscription->isCancelledByAcquirer());
+        $this->assertFalse($subscription->isCancelledByReceiver());
+        $this->assertFalse($subscription->isCancelledByCustomer());
+        $this->assertFalse($subscription->isExpired());
+    }
+
+    public function testIsAutomaticShouldReturnTrue()
+    {
+        $details = new Details('C89', 'R12', '', $this->dDate, $this->eventDate, $this->customer);
+        $subscription = new Subscription('FooBar', $details, 'TRACKER-AAAA', 'auto');
+
+        $this->assertTrue($subscription->isAutomatic());
+        $this->assertFalse($subscription->isManual());
+    }
+
+    public function testIsManualShouldReturnTrue()
+    {
+        $details = new Details('C89', 'R12', '', $this->dDate, $this->eventDate, $this->customer);
+        $subscription = new Subscription('FooBar', $details, 'TRACKER-AAAA', 'manual');
+
+        $this->assertTrue($subscription->isManual());
+        $this->assertFalse($subscription->isAutomatic());
+    }
+
+    public function testIsInitiatedShouldReturnTrue()
+    {
+        $details = new Details('C89', 'R12', 'INITIATED', $this->dDate, $this->eventDate, $this->customer);
+
+        $subscription = new Subscription('FooBar', $details, 'TRACKER-AAAA', 'manual');
+
+        $this->assertTrue($subscription->isInitiated());
+    }
+
+    public function testIsPendingShouldReturnTrue()
+    {
+        $details = new Details('C89', 'R12', 'PENDING', $this->dDate, $this->eventDate, $this->customer);
+
+        $subscription = new Subscription('FooBar', $details, 'TRACKER-AAAA', 'manual');
+
+        $this->assertTrue($subscription->isPending());
+    }
+
+    public function testIsActiveShouldReturnTrue()
+    {
+        $details = new Details('C89', 'R12', 'ACTIVE', $this->dDate, $this->eventDate, $this->customer);
+
+        $subscription = new Subscription('FooBar', $details, 'TRACKER-AAAA', 'manual');
+
+        $this->assertTrue($subscription->isActive());
+    }
+
+    public function testIsCancelledByAcquirerShouldReturnTrue()
+    {
+        $details = new Details('C89', 'R12', 'CANCELLED', $this->dDate, $this->eventDate, $this->customer);
+
+        $subscription = new Subscription('FooBar', $details, 'TRACKER-AAAA', 'manual');
+
+        $this->assertTrue($subscription->isCancelledByAcquirer());
+    }
+
+    public function testIsCancelledByReceiverShouldReturnTrue()
+    {
+        $details = new Details('C89', 'R12', 'CANCELLED_BY_RECEIVER', $this->dDate, $this->eventDate, $this->customer);
+
+        $subscription = new Subscription('FooBar', $details, 'TRACKER-AAAA', 'manual');
+
+        $this->assertTrue($subscription->isCancelledByReceiver());
+    }
+
+    public function testIsCancelledByCustomerShouldReturnTrue()
+    {
+        $details = new Details('C89', 'R12', 'CANCELLED_BY_SENDER', $this->dDate, $this->eventDate, $this->customer);
+
+        $subscription = new Subscription('FooBar', $details, 'TRACKER-AAAA', 'manual');
+
+        $this->assertTrue($subscription->isCancelledByCustomer());
+    }
+
+    public function testIsExpiredShouldReturnTrue()
+    {
+        $details = new Details('C89', 'R12', 'EXPIRED', $this->dDate, $this->eventDate, $this->customer);
+
+        $subscription = new Subscription('FooBar', $details, 'TRACKER-AAAA', 'manual');
+
+        $this->assertTrue($subscription->isExpired());
+    }
+}

--- a/tests/Purchases/Subscriptions/xml/preApproval.xml
+++ b/tests/Purchases/Subscriptions/xml/preApproval.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<preApproval>
+    <name>Seguro Notebook</name>
+    <code>C08984</code>
+    <date>2011-11-23T13:40:00.000-02:00</date>
+    <tracker>538C53</tracker>
+    <status>CANCELLED</status>
+    <reference>REF1234</reference>
+    <lastEventDate>2011-11-25T20:04:00.000-02:00</lastEventDate>
+    <charge>auto</charge>
+    <sender>
+        <name>Nome Comprador</name>
+        <email>comprador@uol.com</email>
+        <phone>
+            <areaCode>11</areaCode>
+        <number>30389678</number>
+        </phone>
+        <address>
+            <street>ALAMEDAITU</street>
+            <number>78</number>
+            <complement>ap.2601</complement>
+            <district>J Paulista</district>
+            <city>SAO PAULO</city>
+            <state>SP</state>
+            <country>BRA</country>
+            <postalCode>01421000</postalCode>
+        </address>
+    </sender>
+</preApproval>

--- a/tests/Purchases/Transactions/DecoderTest.php
+++ b/tests/Purchases/Transactions/DecoderTest.php
@@ -1,0 +1,43 @@
+<?php
+namespace PHPSC\PagSeguro\Purchases\Transactions;
+
+use DateTime;
+use PHPSC\PagSeguro\Purchases\Details;
+use PHPSC\PagSeguro\Customer\Address;
+use PHPSC\PagSeguro\Customer\Customer;
+use PHPSC\PagSeguro\Customer\Phone;
+use PHPSC\PagSeguro\Items\Item;
+use PHPSC\PagSeguro\Items\Items;
+use PHPSC\PagSeguro\Shipping\Shipping;
+
+/**
+ * @author Renato Moura <moura137@gmail.com>
+ */
+class DecoderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDecodeShouldDoReturningObjectTransaction()
+    {
+        $detailsDate = new DateTime('2011-02-10T16:13:41.000-03:00');
+        $detailsLastEventDate = new DateTime('2011-02-10T19:15:11.000-03:00');
+        $detailsAddress = new Address('AC', 'Sao Maite', '99500079', 'Centro', 'R Delgado', '55', 'Fundos');
+        $customer = new Customer('usuario@site.com', 'FooBar', new Phone('11', '99999999'), $detailsAddress);
+        $details = new Details('9E884542', 'REF1234', '6', $detailsDate, $detailsLastEventDate, $customer);
+
+        $paymentMethod = new PaymentMethod(1, 101);
+        $escrowEndDate = new DateTime('2011-03-10T08:00:00.000-03:00');
+        $payment = new Payment($paymentMethod, 49900.00, 0.01, 0.04, 49900.03, 0.02, 1, $escrowEndDate);
+
+        $shippingAddress = new Address('CE', 'Ortega', '40610912', 'Ipe', 'R. Regina', '36', 'Bl.A');
+        $shipping = new Shipping(2, $shippingAddress, 23.45);
+
+        $items = new Items;
+        $items->add(new Item(77, 'Produto 01', 2.5, 4, 20, 300));
+        $items->add(new Item(88, 'Produto 02', 342.51, 3, 134.98, 1000));
+
+        $transaction = new Transaction($details, $payment, 2, $items, $shipping);
+
+        $obj = simplexml_load_file(__DIR__.'/xml/transactionFull.xml');
+        $decoder = new Decoder;
+        $this->assertEquals($transaction, $decoder->decode($obj));
+    }
+}

--- a/tests/Purchases/Transactions/xml/transactionFull.xml
+++ b/tests/Purchases/Transactions/xml/transactionFull.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<transaction>
+    <date>2011-02-10T16:13:41.000-03:00</date>
+    <code>9E884542</code>
+    <reference>REF1234</reference>
+    <type>2</type>
+    <status>6</status>
+    <lastEventDate>2011-02-10T19:15:11.000-03:00</lastEventDate>
+    <escrowEndDate>2011-03-10T08:00:00.000-03:00</escrowEndDate>
+
+    <sender>
+        <email>usuario@site.com</email>
+        <name>FooBar</name>
+        <phone>
+            <areaCode>11</areaCode>
+            <number>99999999</number>
+        </phone>
+        <address>
+            <country>BRA</country>
+            <state>AC</state>
+            <city>Sao Maite</city>
+            <postalCode>99500079</postalCode>
+            <district>Centro</district>
+            <street>R Delgado</street>
+            <number>55</number>
+            <complement>Fundos</complement>
+        </address>
+    </sender>
+
+    <paymentMethod>
+        <type>1</type>
+        <code>101</code>
+    </paymentMethod>
+    <grossAmount>49900.00</grossAmount>
+    <discountAmount>0.01</discountAmount>
+    <feeAmount>0.04</feeAmount>
+    <netAmount>49900.03</netAmount>
+    <extraAmount>0.02</extraAmount>
+    <installmentCount>1</installmentCount>
+    <itemcount>2</itemcount>
+
+    <items>
+        <item>
+            <id>77</id>
+            <description>Produto 01</description>
+            <amount>2.50</amount>
+            <quantity>4</quantity>
+            <weight>300</weight>
+            <shippingCost>20.00</shippingCost>
+        </item>
+        <item>
+            <id>88</id>
+            <description>Produto 02</description>
+            <amount>342.51</amount>
+            <quantity>3</quantity>
+            <weight>1000</weight>
+            <shippingCost>134.98</shippingCost>
+        </item>
+    </items>
+
+
+
+    <shipping>
+        <type>2</type>
+        <cost>23.45</cost>
+        <address>
+            <country>BRA</country>
+            <state>CE</state>
+            <city>Ortega</city>
+            <postalCode>40610912</postalCode>
+            <district>Ipe</district>
+            <street>R. Regina</street>
+            <number>36</number>
+            <complement>Bl.A</complement>
+        </address>
+    </shipping>
+</transaction>

--- a/tests/Requests/PreApprovals/ChargeTypeTest.php
+++ b/tests/Requests/PreApprovals/ChargeTypeTest.php
@@ -1,0 +1,20 @@
+<?php
+namespace PHPSC\PagSeguro\Requests\PreApprovals;
+
+/**
+ * @author Renato Moura <moura137@gmail.com>
+ */
+class ChargeTypeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testValidShouldReturnTrue()
+    {
+        $this->assertTrue(ChargeType::isValid('auto'));
+        $this->assertTrue(ChargeType::isValid('manual'));
+    }
+
+    public function testValuesInvalidShouldReturnFalse()
+    {
+        $this->assertFalse(ChargeType::isValid('AUTO'));
+        $this->assertFalse(ChargeType::isValid('other'));
+    }
+}

--- a/tests/Requests/PreApprovals/PeriodTypeTest.php
+++ b/tests/Requests/PreApprovals/PeriodTypeTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace PHPSC\PagSeguro\Requests\PreApprovals;
+
+/**
+ * @author Renato Moura <moura137@gmail.com>
+ */
+class PeriodTest extends \PHPUnit_Framework_TestCase
+{
+    public function testValidShouldReturnTrue()
+    {
+        $this->assertTrue(Period::isValid('WEEKLY'));
+        $this->assertTrue(Period::isValid('MONTHLY'));
+        $this->assertTrue(Period::isValid('BIMONTHLY'));
+        $this->assertTrue(Period::isValid('TRIMONTHLY'));
+        $this->assertTrue(Period::isValid('SEMIANNUALLY'));
+        $this->assertTrue(Period::isValid('YEARLY'));
+    }
+
+    public function testValuesInvalidShouldReturnFalse()
+    {
+        $this->assertFalse(Period::isValid('Weekly'));
+        $this->assertFalse(Period::isValid('other'));
+    }
+}

--- a/tests/Requests/PreApprovals/PreApprovalServiceTest.php
+++ b/tests/Requests/PreApprovals/PreApprovalServiceTest.php
@@ -1,0 +1,61 @@
+<?php
+namespace PHPSC\PagSeguro\Requests\PreApprovals;
+
+use PHPSC\PagSeguro\Client\Client;
+use PHPSC\PagSeguro\Credentials;
+use PHPSC\PagSeguro\Requests\Redirection;
+use SimpleXMLElement;
+
+/**
+ * @author Renato Moura <moura137@gmail.com>
+ */
+class PreApprovalServiceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateRequestBuilderShouldDoReturnObject()
+    {
+        $credentials = $this->getMock(Credentials::class, [], [], '', false);
+        $client = $this->getMock(Client::class, [], [], '', false);
+        $serializer = $this->getMock(RequestSerializer::class, [], [], '', false);
+
+        $service = new PreApprovalService($credentials, $client, $serializer);
+
+        $this->assertAttributeEquals($serializer, 'serializer', $service);
+        $this->assertAttributeEquals($credentials, 'credentials', $service);
+        $this->assertAttributeEquals($client, 'client', $service);
+
+        $this->assertEquals(new RequestBuilder(true), $service->createRequestBuilder());
+        $this->assertEquals(new RequestBuilder(false), $service->createRequestBuilder(false));
+    }
+
+    public function testAproveShouldReturningTheRedirection()
+    {
+        $request = new Request;
+        $response = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><response/>');
+        $redirect = $this->getMock(Redirection::class, [], [], '', false);
+        $xmlSerialize = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><request/>');
+
+        $credentials = $this->getMock(Credentials::class, [], [], '', false);
+        $client = $this->getMock(Client::class, [], [], '', false);
+        $serializer = $this->getMock(RequestSerializer::class, [], [], '', false);
+
+        $serializer->expects($this->once())->method('serialize')->willReturn($xmlSerialize);
+
+        $service = $this->getMockBuilder(PreApprovalService::class)
+            ->setMethods(['post', 'getRedirection'])
+            ->setConstructorArgs([$credentials, $client, $serializer])
+            ->disableOriginalClone()
+            ->getMock();
+
+        $service->expects($this->once())
+            ->method('post')
+            ->with(PreApprovalService::ENDPOINT, $xmlSerialize)
+            ->willReturn($response);
+
+        $service->expects($this->once())
+            ->method('getRedirection')
+            ->with($response)
+            ->willReturn($redirect);
+
+        $this->assertEquals($redirect, $service->approve($request));
+    }
+}

--- a/tests/Requests/PreApprovals/PreApprovalTest.php
+++ b/tests/Requests/PreApprovals/PreApprovalTest.php
@@ -1,0 +1,84 @@
+<?php
+namespace PHPSC\PagSeguro\Requests\PreApprovals;
+
+use DateTime;
+
+/**
+ * @author Renato Moura <moura137@gmail.com>
+ */
+class PreApprovalTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAttributesShouldValuesEmpty()
+    {
+        $preApproval = new PreApproval;
+
+        $this->assertAttributeEmpty('name', $preApproval);
+        $this->assertAttributeEmpty('chargeType', $preApproval);
+        $this->assertAttributeEmpty('details', $preApproval);
+        $this->assertAttributeEmpty('period', $preApproval);
+        $this->assertAttributeEmpty('finalDate', $preApproval);
+        $this->assertAttributeEmpty('maxTotalAmount', $preApproval);
+        $this->assertAttributeEmpty('amountPerPayment', $preApproval);
+        $this->assertAttributeEmpty('maxAmountPerPayment', $preApproval);
+        $this->assertAttributeEmpty('maxPaymentsPerPeriod', $preApproval);
+        $this->assertAttributeEmpty('maxAmountPerPeriod', $preApproval);
+        $this->assertAttributeEmpty('initialDate', $preApproval);
+    }
+
+    public function testSetChargeTypeShouldThrowInvalidArgumentException()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'You should inform a valid charge type');
+
+        $preApproval = new PreApproval;
+        $preApproval->setChargeType('other');
+    }
+
+    public function testSetPeriodShouldThrowInvalidArgumentException()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'You should inform a valid period');
+
+        $preApproval = new PreApproval;
+        $preApproval->setPeriod('other');
+    }
+
+    public function testSettersAndGettersAttributes()
+    {
+        $preApproval = new PreApproval;
+
+        $preApproval->setName('Name Assinatura');
+        $preApproval->setChargeType('auto');
+        $preApproval->setDetails('Cobranca Mensal');
+        $preApproval->setPeriod('MONTHLY');
+        $preApproval->setFinalDate(new DateTime('2016-11-18'));
+        $preApproval->setMaxTotalAmount(3000);
+        $preApproval->setAmountPerPayment(100);
+        $preApproval->setMaxAmountPerPayment(150);
+        $preApproval->setMaxPaymentsPerPeriod(12);
+        $preApproval->setMaxAmountPerPeriod(1200);
+        $preApproval->setInitialDate(new DateTime('2015-11-18'));
+
+        $this->assertAttributeEquals('Name Assinatura', 'name', $preApproval);
+        $this->assertAttributeEquals('auto', 'chargeType', $preApproval);
+        $this->assertAttributeEquals('Cobranca Mensal', 'details', $preApproval);
+        $this->assertAttributeEquals('MONTHLY', 'period', $preApproval);
+        $this->assertAttributeEquals(new DateTime('2016-11-18'), 'finalDate', $preApproval);
+        $this->assertAttributeEquals(3000, 'maxTotalAmount', $preApproval);
+        $this->assertAttributeEquals(100, 'amountPerPayment', $preApproval);
+        $this->assertAttributeEquals(150, 'maxAmountPerPayment', $preApproval);
+        $this->assertAttributeEquals(12, 'maxPaymentsPerPeriod', $preApproval);
+        $this->assertAttributeEquals(1200, 'maxAmountPerPeriod', $preApproval);
+        $this->assertAttributeEquals(new DateTime('2015-11-18'), 'initialDate', $preApproval);
+
+        $this->assertEquals('Name Assinatura', $preApproval->getName());
+        $this->assertEquals('auto', $preApproval->getChargeType());
+        $this->assertEquals('Cobranca Mensal', $preApproval->getDetails());
+        $this->assertEquals('MONTHLY', $preApproval->getPeriod());
+        $this->assertEquals(new DateTime('2016-11-18'), $preApproval->getFinalDate());
+        $this->assertEquals(3000, $preApproval->getMaxTotalAmount());
+        $this->assertEquals(100, $preApproval->getAmountPerPayment());
+        $this->assertEquals(150, $preApproval->getMaxAmountPerPayment());
+        $this->assertEquals(12, $preApproval->getMaxPaymentsPerPeriod());
+        $this->assertEquals(1200, $preApproval->getMaxAmountPerPeriod());
+        $this->assertEquals(new DateTime('2015-11-18'), $preApproval->getInitialDate());
+    }
+}

--- a/tests/Requests/PreApprovals/RequestBuilderTest.php
+++ b/tests/Requests/PreApprovals/RequestBuilderTest.php
@@ -1,0 +1,78 @@
+<?php
+namespace PHPSC\PagSeguro\Requests\PreApprovals;
+
+use DateTime;
+use PHPSC\PagSeguro\Customer\Customer;
+use PHPSC\PagSeguro\Requests\RequestBuilder as RequestBuilderInterface;
+
+/**
+ * @author Renato Moura <moura137@gmail.com>
+ */
+class RequestBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->mockApproval = $this->getMock(preApproval::class, [], [], '', false);
+        $this->mockApproval->expects($this->once())->method('setChargeType')->with(ChargeType::AUTOMATIC);
+
+        $this->mockRequest = $this->getMock(Request::class, [], [], '', false);
+    }
+
+    public function testContructShouldSetterChargeTypeAndInstanceofInterface()
+    {
+        $this->mockRequest->expects($this->once())->method('getPreApproval')->willReturn($this->mockApproval);
+
+        $builder = new RequestBuilder(false, $this->mockRequest);
+
+        $this->assertInstanceOf(RequestBuilderInterface::class, $builder);
+        $this->assertAttributeEquals($this->mockRequest, 'request', $builder);
+        $this->assertEquals($this->mockRequest, $builder->getRequest());
+    }
+
+    public function testSetterRequestShouldReturnSelfObject()
+    {
+        $this->mockRequest->expects($this->once())->method('getPreApproval')->willReturn($this->mockApproval);
+
+        $customer = $this->getMock(Customer::class, [], [], '', false);
+        $this->mockRequest->expects($this->once())->method('setCustomer')->with($customer);
+        $this->mockRequest->expects($this->once())->method('setRedirectTo')->with('http://redirect');
+        $this->mockRequest->expects($this->once())->method('setReference')->with('ABCDEF');
+        $this->mockRequest->expects($this->once())->method('setReviewOn')->with('http://review');
+
+        $builder = new RequestBuilder(false, $this->mockRequest);
+
+        $this->assertEquals($builder, $builder->setCustomer($customer));
+        $this->assertEquals($builder, $builder->setRedirectTo('http://redirect'));
+        $this->assertEquals($builder, $builder->setReference('ABCDEF'));
+        $this->assertEquals($builder, $builder->setReviewOn('http://review'));
+    }
+
+    public function testSetterPreApprovalShouldReturnSelfObject()
+    {
+        $this->mockRequest->expects($this->exactly(11))->method('getPreApproval')->willReturn($this->mockApproval);
+
+        $this->mockApproval->expects($this->once())->method('setName')->with('FooBar');
+        $this->mockApproval->expects($this->once())->method('setDetails')->with('Details Foo Bar');
+        $this->mockApproval->expects($this->once())->method('setFinalDate')->with(new DateTime('2016-11-18'));
+        $this->mockApproval->expects($this->once())->method('setMaxTotalAmount')->with(2000);
+        $this->mockApproval->expects($this->once())->method('setPeriod')->with('WEEKLY');
+        $this->mockApproval->expects($this->once())->method('setAmountPerPayment')->with(123.56);
+        $this->mockApproval->expects($this->once())->method('setMaxAmountPerPayment')->with(97);
+        $this->mockApproval->expects($this->once())->method('setMaxPaymentsPerPeriod')->with(544.87);
+        $this->mockApproval->expects($this->once())->method('setMaxAmountPerPeriod')->with(5432.90);
+        $this->mockApproval->expects($this->once())->method('setInitialDate')->with(new DateTime('2015-11-18'));
+
+        $builder = new RequestBuilder(false, $this->mockRequest);
+
+        $this->assertEquals($builder, $builder->setName('FooBar'));
+        $this->assertEquals($builder, $builder->setDetails('Details Foo Bar'));
+        $this->assertEquals($builder, $builder->setFinalDate(new DateTime('2016-11-18')));
+        $this->assertEquals($builder, $builder->setMaxTotalAmount(2000));
+        $this->assertEquals($builder, $builder->setPeriod('WEEKLY'));
+        $this->assertEquals($builder, $builder->setAmountPerPayment(123.56));
+        $this->assertEquals($builder, $builder->setMaxAmountPerPayment(97));
+        $this->assertEquals($builder, $builder->setMaxPaymentsPerPeriod(544.87));
+        $this->assertEquals($builder, $builder->setMaxAmountPerPeriod(5432.90));
+        $this->assertEquals($builder, $builder->setInitialDate(new DateTime('2015-11-18')));
+    }
+}

--- a/tests/Shipping/TypeTest.php
+++ b/tests/Shipping/TypeTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace PHPSC\PagSeguro\Shipping;
+
+/**
+ * @author Renato Moura <moura137@gmail.com>
+ */
+class TypeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetTypesShouldDoReturnArray()
+    {
+        $expected = [1, 2, 3];
+        $this->assertEquals($expected, Type::getTypes());
+    }
+
+    public function testValidShouldReturnTrue()
+    {
+        $this->assertTrue(Type::isValid(1));
+        $this->assertTrue(Type::isValid(2));
+        $this->assertTrue(Type::isValid(3));
+    }
+
+    public function testValuesInvalidShouldReturnFalse()
+    {
+        $this->assertFalse(Type::isValid(0));
+        $this->assertFalse(Type::isValid(4));
+    }
+}


### PR DESCRIPTION
issue #22

PHPSC\PagSeguro\Requests\PreApprovals\ChargeType
PHPSC\PagSeguro\Requests\PreApprovals\Period
PHPSC\PagSeguro\Requests\PreApprovals\PreApproval
PHPSC\PagSeguro\Requests\PreApprovals\PreApprovalService
PHPSC\PagSeguro\Requests\PreApprovals\RequestBuilder
PHPSC\PagSeguro\Purchases\Subscriptions\ChargeBuilder.php
PHPSC\PagSeguro\Purchases\Subscriptions\Decoder.php
PHPSC\PagSeguro\Purchases\Subscriptions\Locator.php
PHPSC\PagSeguro\Purchases\Subscriptions\SubscriptionService.php
PHPSC\PagSeguro\Purchases\Subscriptions\Subscription.php
PHPSC\PagSeguro\Purchases\Transactions\Decoder.php