### PR TITLE
Fix Invalid shipping type informed

### DIFF
--- a/src/Purchases/Transactions/Decoder.php
+++ b/src/Purchases/Transactions/Decoder.php
@@ -82,7 +82,7 @@ class Decoder extends BaseDecoder
     protected function createShipping(SimpleXMLElement $shipping)
     {
         return new Shipping(
-            (int) $shipping->type,
+            (int) $shipping->type ?: Type::TYPE_UNKNOWN,
             isset($shipping->address) ? $this->createAddress($shipping->address) : null,
             isset($shipping->cost) ? (float) $shipping->cost : null
         );

--- a/src/Purchases/Transactions/Decoder.php
+++ b/src/Purchases/Transactions/Decoder.php
@@ -6,6 +6,7 @@ use PHPSC\PagSeguro\Items\Item;
 use PHPSC\PagSeguro\Items\Items;
 use PHPSC\PagSeguro\Purchases\Decoder as BaseDecoder;
 use PHPSC\PagSeguro\Shipping\Shipping;
+use PHPSC\PagSeguro\Shipping\Type;
 use SimpleXMLElement;
 
 /**


### PR DESCRIPTION
Quando é efetuada uma venda digitada, ou algum pagamento que não possua frete, ao utilizar o `Locator` é disparado uma excessão `Invalid shipping type informed`, o que não deveria ocorrer, pois de fato, não existe dados de envio.

um exemplo de XML retornado pelo Pagseguro:

```xml
<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>
<transaction>
	<date>2017-10-09T18:00:26.000-03:00</date>
	<code>XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX</code>
	<type>1</type>
	<status>3</status>
	<lastEventDate>2017-10-09T18:00:36.000-03:00</lastEventDate>
	<paymentMethod>
		<type>1</type>
		<code>107</code>
	</paymentMethod>
	<grossAmount>219.80</grossAmount>
	<discountAmount>0.00</discountAmount>
	<feeAmount>19.37</feeAmount>
	<netAmount>200.43</netAmount>
	<extraAmount>0.00</extraAmount>
	<escrowEndDate>2017-11-08T19:00:26.000-02:00</escrowEndDate>
	<installmentCount>2</installmentCount>
	<itemCount>1</itemCount>
	<items>
		<item>
			<id>1</id>
			<description>Venda digitada</description>
			<quantity>1</quantity>
			<amount>219.80</amount>
		</item>
	</items>
</transaction>
```