### PR TITLE
PHPUnit\Framework\TestCase ao invés de PHPUnit_Framework_TestCase

### DIFF
--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -5,8 +5,9 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Client as HttpClient;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use PHPUnit\Framework\TestCase;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     /**
      * @var HttpClient|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Client/PagSeguroExceptionTest.php
+++ b/tests/Client/PagSeguroExceptionTest.php
@@ -2,8 +2,9 @@
 namespace PHPSC\PagSeguro\Client;
 
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class PagSeguroExceptionTest extends \PHPUnit_Framework_TestCase
+class PagSeguroExceptionTest extends TestCase
 {
     /**
      * @test

--- a/tests/CredentialsTest.php
+++ b/tests/CredentialsTest.php
@@ -2,11 +2,12 @@
 namespace PHPSC\PagSeguro;
 
 use PHPSC\PagSeguro\Environments\Production;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  */
-class CredentialsTest extends \PHPUnit_Framework_TestCase
+class CredentialsTest extends TestCase
 {
     /**
      * @var Environment

--- a/tests/Customer/AddressTest.php
+++ b/tests/Customer/AddressTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace PHPSC\PagSeguro\Customer;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AddressTest extends TestCase
 {
     /**
      * @var Address

--- a/tests/Customer/CustomerTest.php
+++ b/tests/Customer/CustomerTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace PHPSC\PagSeguro\Customer;
 
-class CustomerTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class CustomerTest extends TestCase
 {
     /**
      * @test

--- a/tests/Customer/PhoneTest.php
+++ b/tests/Customer/PhoneTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace PHPSC\PagSeguro\Customer;
 
-class PhoneTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PhoneTest extends TestCase
 {
     /**
      * @test
@@ -32,7 +34,7 @@ class PhoneTest extends \PHPUnit_Framework_TestCase
     {
 
         $data = simplexml_load_string('<?xml version="1.0" encoding="UTF-8"?><data />');
-        
+
         $phone = new Phone(47, 1234567890);
         $xml = $phone->xmlSerialize($data);
 

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -3,11 +3,12 @@ namespace PHPSC\PagSeguro;
 
 use PHPSC\PagSeguro\Environments\Production;
 use PHPSC\PagSeguro\Environments\Sandbox;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  */
-class EnvironmentTest extends \PHPUnit_Framework_TestCase
+class EnvironmentTest extends TestCase
 {
     /**
      * @var Environment

--- a/tests/Environments/ProductionTest.php
+++ b/tests/Environments/ProductionTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace PHPSC\PagSeguro\Environments;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  */
-class ProductionTest extends \PHPUnit_Framework_TestCase
+class ProductionTest extends TestCase
 {
     /**
      * @test

--- a/tests/Environments/SandboxTest.php
+++ b/tests/Environments/SandboxTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace PHPSC\PagSeguro\Environments;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  */
-class SandboxTest extends \PHPUnit_Framework_TestCase
+class SandboxTest extends TestCase
 {
     /**
      * @test

--- a/tests/Items/ItemTest.php
+++ b/tests/Items/ItemTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace PHPSC\PagSeguro\Items;
 
-class ItemTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ItemTest extends TestCase
 {
     /**
      * @var Item

--- a/tests/Items/ItemsTest.php
+++ b/tests/Items/ItemsTest.php
@@ -2,11 +2,12 @@
 namespace PHPSC\PagSeguro\Items;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Renato Moura <moura137@gmail.com>
  */
-class ItemsTest extends \PHPUnit_Framework_TestCase
+class ItemsTest extends TestCase
 {
     /**
      * @test

--- a/tests/Purchases/DetailsTest.php
+++ b/tests/Purchases/DetailsTest.php
@@ -3,11 +3,12 @@ namespace PHPSC\PagSeguro\Purchases;
 
 use DateTime;
 use PHPSC\PagSeguro\Customer\Customer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Adelar Tiemann Junior <adelar@adelarcubs.com>
  */
-class DetailsTest extends \PHPUnit_Framework_TestCase
+class DetailsTest extends TestCase
 {
     /**
      * @var Details

--- a/tests/Purchases/Subscriptions/CancellationResponseTest.php
+++ b/tests/Purchases/Subscriptions/CancellationResponseTest.php
@@ -2,11 +2,12 @@
 namespace PHPSC\PagSeguro\Purchases\Subscriptions;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Adelar Tiemann Junior <adelar@adelarcubs.com>
  */
-class CancellationResponseTest extends \PHPUnit_Framework_TestCase
+class CancellationResponseTest extends TestCase
 {
     /**
      * @var CancellationResponse

--- a/tests/Purchases/Subscriptions/ChargeBuilderTest.php
+++ b/tests/Purchases/Subscriptions/ChargeBuilderTest.php
@@ -4,11 +4,12 @@ namespace PHPSC\PagSeguro\Purchases\Subscriptions;
 use PHPSC\PagSeguro\Purchases\ChargeBuilder as ChargeBuilderInterface;
 use PHPSC\PagSeguro\Items\Item;
 use PHPSC\PagSeguro\Items\Items;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Renato Moura <moura137@gmail.com>
  */
-class ChargeBuilderTest extends \PHPUnit_Framework_TestCase
+class ChargeBuilderTest extends TestCase
 {
     private $charge;
 

--- a/tests/Purchases/Subscriptions/ChargeResponseTest.php
+++ b/tests/Purchases/Subscriptions/ChargeResponseTest.php
@@ -2,11 +2,12 @@
 namespace PHPSC\PagSeguro\Purchases\Subscriptions;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Adelar Tiemann Junior <adelar@adelarcubs.com>
  */
-class ChargeResponseTest extends \PHPUnit_Framework_TestCase
+class ChargeResponseTest extends TestCase
 {
     /**
      * @var ChargeResponse

--- a/tests/Purchases/Subscriptions/ChargeTest.php
+++ b/tests/Purchases/Subscriptions/ChargeTest.php
@@ -5,11 +5,12 @@ use SimpleXMLElement;
 use PHPSC\PagSeguro\Items\Items;
 use PHPSC\PagSeguro\Items\Item;
 use PHPSC\PagSeguro\Items\ItemCollection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Adelar Tiemann Junior <adelar@adelarcubs.com>
  */
-class ChargeTest extends \PHPUnit_Framework_TestCase
+class ChargeTest extends TestCase
 {
     /**
      * @var Charge
@@ -36,7 +37,7 @@ class ChargeTest extends \PHPUnit_Framework_TestCase
     {
         $charge = new Charge();
         $charge->setReference('SomeRef');
-        
+
         $this->assertAttributeEquals('SomeRef', 'reference', $charge);
         $this->assertEquals('SomeRef', $charge->getReference());
     }
@@ -48,7 +49,7 @@ class ChargeTest extends \PHPUnit_Framework_TestCase
     {
         $charge = new Charge();
         $charge->setSubscriptionCode('SomeSubscription');
-        
+
         $this->assertAttributeEquals('SomeSubscription', 'subscriptionCode', $charge);
         $this->assertEquals('SomeSubscription', $charge->getSubscriptionCode());
     }

--- a/tests/Purchases/Subscriptions/DecoderTest.php
+++ b/tests/Purchases/Subscriptions/DecoderTest.php
@@ -6,11 +6,12 @@ use PHPSC\PagSeguro\Purchases\Details;
 use PHPSC\PagSeguro\Customer\Address;
 use PHPSC\PagSeguro\Customer\Customer;
 use PHPSC\PagSeguro\Customer\Phone;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Renato Moura <moura137@gmail.com>
  */
-class DecoderTest extends \PHPUnit_Framework_TestCase
+class DecoderTest extends TestCase
 {
     public function testDecodeShouldDoReturningObjectSubscription()
     {

--- a/tests/Purchases/Subscriptions/LocatorTest.php
+++ b/tests/Purchases/Subscriptions/LocatorTest.php
@@ -8,11 +8,12 @@ use PHPSC\PagSeguro\Purchases\SearchService;
 use PHPSC\PagSeguro\Service;
 use PHPSC\PagSeguro\Purchases\Transactions\Transaction;
 use SimpleXMLElement;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Renato Moura <moura137@gmail.com>
  */
-class LocatorTest extends \PHPUnit_Framework_TestCase
+class LocatorTest extends TestCase
 {
     public function testConstructShouldSettersDecoder()
     {

--- a/tests/Purchases/Subscriptions/SubscriptionServiceTest.php
+++ b/tests/Purchases/Subscriptions/SubscriptionServiceTest.php
@@ -7,11 +7,12 @@ use PHPSC\PagSeguro\Credentials;
 use PHPSC\PagSeguro\Client\Client;
 use DateTime;
 use SimpleXMLElement;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Renato Moura <moura137@gmail.com>
  */
-class SubscriptionServiceTest extends \PHPUnit_Framework_TestCase
+class SubscriptionServiceTest extends TestCase
 {
     /**
      * @var Credentials|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Purchases/Subscriptions/SubscriptionTest.php
+++ b/tests/Purchases/Subscriptions/SubscriptionTest.php
@@ -6,11 +6,12 @@ use PHPSC\PagSeguro\Purchases\Details;
 use PHPSC\PagSeguro\Customer\Address;
 use PHPSC\PagSeguro\Customer\Customer;
 use PHPSC\PagSeguro\Customer\Phone;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Renato Moura <moura137@gmail.com>
  */
-class SubscriptionTest extends \PHPUnit_Framework_TestCase
+class SubscriptionTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/Purchases/Transactions/DecoderTest.php
+++ b/tests/Purchases/Transactions/DecoderTest.php
@@ -9,11 +9,12 @@ use PHPSC\PagSeguro\Customer\Phone;
 use PHPSC\PagSeguro\Items\Item;
 use PHPSC\PagSeguro\Items\Items;
 use PHPSC\PagSeguro\Shipping\Shipping;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Renato Moura <moura137@gmail.com>
  */
-class DecoderTest extends \PHPUnit_Framework_TestCase
+class DecoderTest extends TestCase
 {
     public function testDecodeShouldDoReturningObjectTransaction()
     {

--- a/tests/Purchases/Transactions/LocatorTest.php
+++ b/tests/Purchases/Transactions/LocatorTest.php
@@ -4,11 +4,12 @@ namespace PHPSC\PagSeguro\Purchases\Transactions;
 use PHPSC\PagSeguro\Credentials;
 use PHPSC\PagSeguro\Client\Client;
 use PHPSC\PagSeguro\Environment;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  */
-class LocatorTest extends \PHPUnit_Framework_TestCase
+class LocatorTest extends TestCase
 {
     /**
      * @var Credentials

--- a/tests/Purchases/Transactions/PaymentMethodTest.php
+++ b/tests/Purchases/Transactions/PaymentMethodTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace PHPSC\PagSeguro\Purchases\Transactions;
 
-class PaymentMethodTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PaymentMethodTest extends TestCase
 {
     public function testRealCase01()
     {

--- a/tests/Purchases/Transactions/PaymentTest.php
+++ b/tests/Purchases/Transactions/PaymentTest.php
@@ -2,22 +2,23 @@
 namespace PHPSC\PagSeguro\Purchases\Transactions;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Adelar Tiemann Junior <adelar@adelarcubs.com>
  */
-class PaymentTest extends \PHPUnit_Framework_TestCase
+class PaymentTest extends TestCase
 {
     /**
      * @var Payment
      */
     private $payment;
-    
+
     /**
      * @var DateTime
      */
     private $escrowEndDate;
-    
+
     /**
      * @var PaymentMethod
      */

--- a/tests/Purchases/Transactions/TransactionTest.php
+++ b/tests/Purchases/Transactions/TransactionTest.php
@@ -5,32 +5,33 @@ use DateTime;
 use PHPSC\PagSeguro\Shipping\Shipping;
 use PHPSC\PagSeguro\Purchases\Details;
 use PHPSC\PagSeguro\Items\ItemCollection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Adelar Tiemann Junior <adelar@adelarcubs.com>
  */
-class TransactionTest extends \PHPUnit_Framework_TestCase
+class TransactionTest extends TestCase
 {
     /**
      * @var Transaction
      */
     private $transaction;
-       
+
     /**
      * @var Details
      */
     private $details;
-    
+
     /**
      * @var Payment
      */
     private $payment;
-    
+
     /**
      * @var ItemCollection
      */
     private $itemCollection;
-    
+
     /**
      * @var Shipping
      */
@@ -42,7 +43,7 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
         $this->payment        = $this->createMock(Payment::class);
         $this->itemCollection = $this->createMock(ItemCollection::class);
         $this->shipping       = $this->createMock(Shipping::class);
-        
+
         $this->transaction = new Transaction(
             $this->details,
             $this->payment,

--- a/tests/Requests/Checkout/CheckoutBuilderTest.php
+++ b/tests/Requests/Checkout/CheckoutBuilderTest.php
@@ -4,11 +4,12 @@ namespace PHPSC\PagSeguro\Requests\Checkout;
 use PHPSC\PagSeguro\Customer\Customer;
 use PHPSC\PagSeguro\Items\Item;
 use PHPSC\PagSeguro\Shipping\Shipping;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  */
-class CheckoutBuilderTest extends \PHPUnit_Framework_TestCase
+class CheckoutBuilderTest extends TestCase
 {
     /**
      * @var Checkout

--- a/tests/Requests/Checkout/CheckoutServiceTest.php
+++ b/tests/Requests/Checkout/CheckoutServiceTest.php
@@ -6,11 +6,12 @@ use PHPSC\PagSeguro\Client\Client;
 use PHPSC\PagSeguro\Credentials;
 use PHPSC\PagSeguro\Environment;
 use PHPSC\PagSeguro\Requests\Redirection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  */
-class CheckoutServiceTest extends \PHPUnit_Framework_TestCase
+class CheckoutServiceTest extends TestCase
 {
     /**
      * @var Client|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Requests/Checkout/CheckoutTest.php
+++ b/tests/Requests/Checkout/CheckoutTest.php
@@ -9,11 +9,12 @@ use PHPSC\PagSeguro\Shipping\Shipping;
 use PHPSC\PagSeguro\Customer\Customer;
 use PHPSC\PagSeguro\Customer\Phone;
 use PHPSC\PagSeguro\Customer\Address;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  */
-class CheckoutTest extends \PHPUnit_Framework_TestCase
+class CheckoutTest extends TestCase
 {
     /**
      * @var Checkout

--- a/tests/Requests/Checkout/OrderTest.php
+++ b/tests/Requests/Checkout/OrderTest.php
@@ -3,11 +3,12 @@ namespace PHPSC\PagSeguro\Requests\Checkout;
 
 use PHPSC\PagSeguro\Items\ItemCollection;
 use PHPSC\PagSeguro\Shipping\Shipping;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  */
-class OrderTest extends \PHPUnit_Framework_TestCase
+class OrderTest extends TestCase
 {
     /**
      * @var ItemCollection

--- a/tests/Requests/PreApprovals/ChargeTypeTest.php
+++ b/tests/Requests/PreApprovals/ChargeTypeTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace PHPSC\PagSeguro\Requests\PreApprovals;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author Renato Moura <moura137@gmail.com>
  */
-class ChargeTypeTest extends \PHPUnit_Framework_TestCase
+class ChargeTypeTest extends TestCase
 {
     public function testValidShouldReturnTrue()
     {

--- a/tests/Requests/PreApprovals/PeriodTypeTest.php
+++ b/tests/Requests/PreApprovals/PeriodTypeTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace PHPSC\PagSeguro\Requests\PreApprovals;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author Renato Moura <moura137@gmail.com>
  */
-class PeriodTest extends \PHPUnit_Framework_TestCase
+class PeriodTest extends TestCase
 {
     public function testValidShouldReturnTrue()
     {

--- a/tests/Requests/PreApprovals/PreApprovalServiceTest.php
+++ b/tests/Requests/PreApprovals/PreApprovalServiceTest.php
@@ -5,11 +5,12 @@ use PHPSC\PagSeguro\Client\Client;
 use PHPSC\PagSeguro\Credentials;
 use PHPSC\PagSeguro\Requests\Redirection;
 use SimpleXMLElement;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Renato Moura <moura137@gmail.com>
  */
-class PreApprovalServiceTest extends \PHPUnit_Framework_TestCase
+class PreApprovalServiceTest extends TestCase
 {
     /**
      * @test

--- a/tests/Requests/PreApprovals/PreApprovalTest.php
+++ b/tests/Requests/PreApprovals/PreApprovalTest.php
@@ -2,11 +2,12 @@
 namespace PHPSC\PagSeguro\Requests\PreApprovals;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Renato Moura <moura137@gmail.com>
  */
-class PreApprovalTest extends \PHPUnit_Framework_TestCase
+class PreApprovalTest extends TestCase
 {
     public function testAttributesShouldValuesEmpty()
     {

--- a/tests/Requests/PreApprovals/RequestBuilderTest.php
+++ b/tests/Requests/PreApprovals/RequestBuilderTest.php
@@ -4,11 +4,12 @@ namespace PHPSC\PagSeguro\Requests\PreApprovals;
 use DateTime;
 use PHPSC\PagSeguro\Customer\Customer;
 use PHPSC\PagSeguro\Requests\RequestBuilder as RequestBuilderInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Renato Moura <moura137@gmail.com>
  */
-class RequestBuilderTest extends \PHPUnit_Framework_TestCase
+class RequestBuilderTest extends TestCase
 {
     /**
      * @var PreApproval|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Requests/PreApprovals/RequestTest.php
+++ b/tests/Requests/PreApprovals/RequestTest.php
@@ -6,11 +6,12 @@ use DateTime;
 use PHPSC\PagSeguro\Customer\Customer;
 use PHPSC\PagSeguro\Customer\Phone;
 use PHPSC\PagSeguro\Customer\Address;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Adelar Tiemann Junior <adelar@adelarcubs.com>
  */
-class RequestTest extends \PHPUnit_Framework_TestCase
+class RequestTest extends TestCase
 {
     /**
      * @var Request

--- a/tests/Requests/RedirectionTest.php
+++ b/tests/Requests/RedirectionTest.php
@@ -2,8 +2,9 @@
 namespace PHPSC\PagSeguro\Requests;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 
-class RedirectionTest extends \PHPUnit_Framework_TestCase
+class RedirectionTest extends TestCase
 {
     /**
      * @var Redirection

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -2,11 +2,12 @@
 namespace PHPSC\PagSeguro;
 
 use PHPSC\PagSeguro\Client\Client;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  */
-class ServiceTest extends \PHPUnit_Framework_TestCase
+class ServiceTest extends TestCase
 {
     /**
      * @var Credentials

--- a/tests/Shipping/ShippingTest.php
+++ b/tests/Shipping/ShippingTest.php
@@ -2,8 +2,9 @@
 namespace PHPSC\PagSeguro\Shipping;
 
 use PHPSC\PagSeguro\Customer\Address;
+use PHPUnit\Framework\TestCase;
 
-class ShippingTest extends \PHPUnit_Framework_TestCase
+class ShippingTest extends TestCase
 {
     /**
      * @test

--- a/tests/Shipping/TypeTest.php
+++ b/tests/Shipping/TypeTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace PHPSC\PagSeguro\Shipping;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author Renato Moura <moura137@gmail.com>
  */
-class TypeTest extends \PHPUnit_Framework_TestCase
+class TypeTest extends TestCase
 {
     public function testGetTypesShouldDoReturnArray()
     {


### PR DESCRIPTION
Usei `PHPUnit\Framework\TestCase` ao invés de `PHPUnit_Framework_TestCase` enquanto extendendo a classe `PHPUnit TestCase`. Isso irá nos ajudar quando migrarmos para o `PHPUnit 6`, que [não mais suporta _snake case namespaces_](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).