### PR TITLE
Tamanho do Token do PagSeguro para 100 caracteres

### DIFF
--- a/src/Credentials.php
+++ b/src/Credentials.php
@@ -32,7 +32,7 @@ class Credentials
     public function __construct($email, $token, Environment $environment = null)
     {
         $this->email = substr($email, 0, 60);
-        $this->token = substr($token, 0, 32);
+        $this->token = substr($token, 0, 100);
         $this->environment = $environment ?: new Production();
     }
 

--- a/src/Purchases/Subscriptions/Charge.php
+++ b/src/Purchases/Subscriptions/Charge.php
@@ -9,7 +9,7 @@ use PHPSC\PagSeguro\SerializerTrait;
 /**
  * @Serializer\AccessType("public_method")
  * @Serializer\ReadOnly
- * @Serializer\XmlRoot("charge")
+ * @Serializer\XmlRoot("payment")
  *
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
  */


### PR DESCRIPTION
Corrige tamanho do Token do PagSeguro para 100 caracteres ao invés de 32, que é o novo padrão.